### PR TITLE
remove uvicorn 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ pydantic==1.8.2
 python-decouple==3.4
 starlette==0.14.2
 typing-extensions==3.10.0.0
-uvicorn==0.14.0


### PR DESCRIPTION
removed uvicorn since it's not needed by the deta micro and conflicts with the other dependencies when running 'deta deploy'